### PR TITLE
Fix setting cookie on server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function handle (cookie, action) {
 
 function map (cookieMap) {
   return function (name, value) {
-    if (arguments.length === 2) {
+    if (arguments.length > 1) {
       cookieMap[name] = value
     }
 


### PR DESCRIPTION
The cookie map is checking for exactly 2 arguments but 3 are always passed.
